### PR TITLE
Bump ecmaVersion

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     parserOptions: {
-        ecmaVersion: 2018,
+        ecmaVersion: 2020,
         sourceType: 'script',
     },
     env: {


### PR DESCRIPTION
Fix support for optional chaining added in Node v15. See details at https://stackoverflow.com/questions/57378411/eslint-fails-to-parse-and-red-highlights-optional-chaining-and-nullish-coal . 